### PR TITLE
SSI-616: Resolve Spring container issues

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -1,0 +1,9 @@
+general:
+  vulnerabilities:
+    - CVE-2016-1000027 # https://github.com/spring-projects/spring-framework/issues/24434
+    - CVE-2022-25857 # https://github.com/spring-projects/spring-boot/issues/32221
+  bestPracticeViolations:
+    # These are info level issues, coming from buildpacks, we cant fix them
+    - CIS-DI-0005
+    - CIS-DI-0006
+    - CIS-DI-0008

--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ subprojects {
 			builder = "paketobuildpacks/builder:full"
 			buildpacks(
 					[
-							"gcr.io/paketo-buildpacks/eclipse-openj9:9.8.0",
+							"gcr.io/paketo-buildpacks/eclipse-openj9:9.8.2",
 							"urn:cnb:builder:paketo-buildpacks/java" // https://github.com/spring-projects/spring-boot/issues/31233#issuecomment-1145220375
 					]
 			)

--- a/svc-aca-py/build.gradle
+++ b/svc-aca-py/build.gradle
@@ -14,3 +14,10 @@ task buildImage(type: DockerBuildImage, group: 'docker') {
 pushBuildImage {
 	images.add(svcAcaPyImageFullName)
 }
+
+task printImageFullName {
+	doLast {
+		println "${svcAcaPyImageFullName}"
+		new File(buildDir, "acaPyImageTag").text = "${svcAcaPyImageFullName}"
+	}
+}


### PR DESCRIPTION
The existing vulnerabilties and best practice problems do not apply to us, either they are false positives, or minor issues we cant fix. Updating to latest openj9 image.
Also enabling the vulnerability scan for the wallet. We might decide to drop this scan, as the base image is not ours and we cant directly fix issues in that.