### PR TITLE
Image retag

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -8,8 +8,22 @@ on:
     - cron: '0 5 * * 2,5'
 
 jobs:
-  ui-issuer:
+  container-scan:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - subproject: ui-issuer
+          - subproject: ui-verifier
+          - subproject: api-connector
+          - subproject: api-issuer
+          - subproject: api-verifier
+          - subproject: svc-aca-py
+          - subproject: svc-aries-facade
+          - subproject: svc-webhook
+
+    name: Scanning ${{ matrix.subproject }} container
 
     steps:
       - uses: actions/checkout@v3
@@ -28,11 +42,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Build ui-issuer docker image
-        run: ./gradlew ui-issuer:buildImage
+      - name: Build ${{ matrix.subproject }} docker image
+        run: ./gradlew ${{ matrix.subproject }}:buildImage
 
       - name: Saving image name to environment variable
-        run: echo "IMAGE_NAME=$(./gradlew -q ui-issuer:printImageFullName | tail -n 1)" >> $GITHUB_ENV
+        run: echo "IMAGE_NAME=$(./gradlew -q ${{ matrix.subproject }}:printImageFullName | tail -n 1)" >> $GITHUB_ENV
 
       - name: Run Vulnerability scanning and CIS benchmark against image
         uses: Azure/container-scan@v0
@@ -42,240 +56,3 @@ jobs:
           # See https://github.com/goodwithtech/dockle/issues/188
           DOCKLE_HOST: "unix:///var/run/docker.sock"
 
-  ui-verifier:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
-          java-version: '11'
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Build ui-verifier docker image
-        run: ./gradlew ui-verifier:buildImage
-
-      - name: Saving image name to environment variable
-        run: echo "IMAGE_NAME=$(./gradlew -q ui-verifier:printImageFullName | tail -n 1)" >> $GITHUB_ENV
-
-      - name: Run Vulnerability scanning and CIS benchmark against image
-        uses: Azure/container-scan@v0
-        with:
-          image-name: ${{ env.IMAGE_NAME }}
-        env:
-          # See https://github.com/goodwithtech/dockle/issues/188
-          DOCKLE_HOST: "unix:///var/run/docker.sock"
-
-  api-connector:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
-          java-version: '11'
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Build api-connector docker image
-        run: ./gradlew api-connector:bootBuildImage
-
-      - name: Saving image name to environment variable
-        run: echo "IMAGE_NAME=$(./gradlew -q api-connector:printImageFullName | tail -n 1)" >> $GITHUB_ENV
-
-      - name: Run Vulnerability scanning and CIS benchmark against image
-        uses: Azure/container-scan@v0
-        with:
-          image-name: ${{ env.IMAGE_NAME }}
-        env:
-          # See https://github.com/goodwithtech/dockle/issues/188
-          DOCKLE_HOST: "unix:///var/run/docker.sock"
-
-  issuer-server:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
-          java-version: '11'
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Build api-issuer docker image
-        run: ./gradlew api-issuer:bootBuildImage
-
-      - name: Saving image name to environment variable
-        run: echo "API_ISSUER_IMAGE_NAME=$(./gradlew -q api-issuer:printImageFullName | tail -n 1)" >> $GITHUB_ENV
-
-      - name: Run Vulnerability scanning and CIS benchmark against api-issuer image
-        uses: Azure/container-scan@v0
-        with:
-          image-name: ${{ env.API_ISSUER_IMAGE_NAME }}
-        env:
-          # See https://github.com/goodwithtech/dockle/issues/188
-          DOCKLE_HOST: "unix:///var/run/docker.sock"
-
-  verifier-server:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
-          java-version: '11'
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Build api-verifier docker image
-        run: ./gradlew api-verifier:bootBuildImage
-
-      - name: Saving image name to environment variable
-        run: echo "API_VERIFIER_IMAGE_NAME=$(./gradlew -q api-verifier:printImageFullName | tail -n 1)" >> $GITHUB_ENV
-
-      - name: Run Vulnerability scanning and CIS benchmark against api-verifier image
-        uses: Azure/container-scan@v0
-        with:
-          image-name: ${{ env.API_VERIFIER_IMAGE_NAME }}
-        env:
-          # See https://github.com/goodwithtech/dockle/issues/188
-          DOCKLE_HOST: "unix:///var/run/docker.sock"
-
-  wallet:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
-          java-version: '11'
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Build svc-aca-py docker image
-        run: ./gradlew svc-aca-py:buildImage
-
-      - name: Saving image name to environment variable
-        run: echo "SVC_ACA_PY_IMAGE_NAME=$(./gradlew -q svc-aca-py:printImageFullName | tail -n 1)" >> $GITHUB_ENV
-
-      - name: Run Vulnerability scanning and CIS benchmark against svc-aca-py image
-        uses: Azure/container-scan@v0
-        with:
-          image-name: ${{ env.SVC_ACA_PY_IMAGE_NAME }}
-        env:
-          # See https://github.com/goodwithtech/dockle/issues/188
-          DOCKLE_HOST: "unix:///var/run/docker.sock"
-
-  aries-facade:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
-          java-version: '11'
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Build svc-aries-facade docker image
-        run: ./gradlew svc-aries-facade:bootBuildImage
-
-      - name: Saving image name to environment variable
-        run: echo "SVC_ARIES_FACADE_IMAGE_NAME=$(./gradlew -q svc-aries-facade:printImageFullName | tail -n 1)" >> $GITHUB_ENV
-
-      - name: Run Vulnerability scanning and CIS benchmark against Aries Facade image
-        uses: Azure/container-scan@v0
-        with:
-          image-name: ${{ env.SVC_ARIES_FACADE_IMAGE_NAME }}
-        env:
-          # See https://github.com/goodwithtech/dockle/issues/188
-          DOCKLE_HOST: "unix:///var/run/docker.sock"
-
-  webhook:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
-          java-version: '11'
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Build svc-webhook docker image
-        run: ./gradlew svc-webhook:bootBuildImage
-
-      - name: Saving image name to environment variable
-        run: echo "SVC_WEBHOOK_IMAGE_NAME=$(./gradlew -q svc-webhook:printImageFullName | tail -n 1)" >> $GITHUB_ENV
-
-      - name: Run Vulnerability scanning and CIS benchmark against svc-webhook image
-        uses: Azure/container-scan@v0
-        with:
-          image-name: ${{ env.SVC_WEBHOOK_IMAGE_NAME }}
-        env:
-          # See https://github.com/goodwithtech/dockle/issues/188
-          DOCKLE_HOST: "unix:///var/run/docker.sock"

--- a/.github/workflows/main-workflow.yml
+++ b/.github/workflows/main-workflow.yml
@@ -54,7 +54,7 @@ jobs:
         run: ./gradlew buildAllImages
 
       - name: Push docker images to registry
-        run: ./gradlew pushAllImages
+        run: ./gradlew pushBuildImage
 
       - name: Get build version
         id: current_build

--- a/api-connector/build.gradle
+++ b/api-connector/build.gradle
@@ -41,8 +41,6 @@ configurations {
 ext {
 	buildImageName = apiConnectorImageName
 	buildImageFullName = apiConnectorImageFullname
-	buildImageLatestTag = "${apiConnectorImageName}:latest"
-	releaseImageFullName = "${apiConnectorImageName}:${BUILD_VERSION_PREFIX}"
 }
 
 // db

--- a/api-connector/build.gradle
+++ b/api-connector/build.gradle
@@ -38,20 +38,11 @@ configurations {
 	}
 }
 
-task printImageFullName {
-	doLast {
-		println "${apiConnectorImageFullname}"
-		new File(buildDir, "connectorImageTag").text = "${apiConnectorImageFullname}"
-	}
-}
-
-bootBuildImage {
-	imageName = apiConnectorImageFullname
-	tags = ["${apiConnectorImageName}:latest"]
-}
-
-pushBuildImage {
-	images.add(apiConnectorImageFullname)
+ext {
+	buildImageName = apiConnectorImageName
+	buildImageFullName = apiConnectorImageFullname
+	buildImageLatestTag = "${apiConnectorImageName}:latest"
+	releaseImageFullName = "${apiConnectorImageName}:${BUILD_VERSION_PREFIX}"
 }
 
 // db

--- a/api-issuer/build.gradle
+++ b/api-issuer/build.gradle
@@ -46,6 +46,13 @@ configurations {
 	}
 }
 
+ext {
+	buildImageName = apiIssuerImageName
+	buildImageFullName = apiIssuerImageFullName
+	buildImageLatestTag = "${apiIssuerImageName}:latest"
+	releaseImageFullName = "${apiIssuerImageName}:${BUILD_VERSION_PREFIX}"
+}
+
 test {
 	useJUnitPlatform()
 }
@@ -68,19 +75,4 @@ tasks.named("bootJarMainClassName").configure {dependsOn generateSchema}
 jpaSchemaGen {
 	persistenceUnitName = "ISSUER-UNIT"
 	packageName = "com.adnovum.vcms.issuer.datamodel.ddl"
-}
-
-bootBuildImage {
-	imageName = apiIssuerImageFullName
-	tags = ["${apiIssuerImageName}:latest"]}
-
-pushBuildImage {
-	images.add(apiIssuerImageFullName)
-}
-
-task printImageFullName {
-	doLast {
-		println "${apiIssuerImageFullName}"
-		new File(buildDir, "issuerServerImageTag").text = "${apiIssuerImageFullName}"
-	}
 }

--- a/api-issuer/build.gradle
+++ b/api-issuer/build.gradle
@@ -49,8 +49,6 @@ configurations {
 ext {
 	buildImageName = apiIssuerImageName
 	buildImageFullName = apiIssuerImageFullName
-	buildImageLatestTag = "${apiIssuerImageName}:latest"
-	releaseImageFullName = "${apiIssuerImageName}:${BUILD_VERSION_PREFIX}"
 }
 
 test {

--- a/api-verifier/build.gradle
+++ b/api-verifier/build.gradle
@@ -45,20 +45,11 @@ configurations {
 	}
 }
 
-bootBuildImage {
-	imageName = apiVerifierImageFullName
-	tags = ["${apiVerifierImageName}:latest"]
-}
-
-pushBuildImage {
-	images.add(apiVerifierImageFullName)
-}
-
-task printImageFullName {
-	doLast {
-		println "${apiVerifierImageFullName}"
-		new File(buildDir, "verifierServerImageTag").text = "${apiVerifierImageFullName}"
-	}
+ext {
+	buildImageName = apiVerifierImageName
+	buildImageFullName = apiVerifierImageFullName
+	buildImageLatestTag = "${apiVerifierImageName}:latest"
+	releaseImageFullName = "${apiVerifierImageName}:${BUILD_VERSION_PREFIX}"
 }
 
 // db schema

--- a/api-verifier/build.gradle
+++ b/api-verifier/build.gradle
@@ -48,8 +48,6 @@ configurations {
 ext {
 	buildImageName = apiVerifierImageName
 	buildImageFullName = apiVerifierImageFullName
-	buildImageLatestTag = "${apiVerifierImageName}:latest"
-	releaseImageFullName = "${apiVerifierImageName}:${BUILD_VERSION_PREFIX}"
 }
 
 // db schema

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 import com.bmuschko.gradle.docker.tasks.image.DockerPushImage
+import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
+import com.bmuschko.gradle.docker.tasks.image.DockerTagImage
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
 
@@ -8,7 +10,7 @@ plugins {
 	id 'jacoco'
 	alias(libs.plugins.bmuschko.docker) apply false
 	alias(libs.plugins.grgit)
-    alias(libs.plugins.jpa.schema.gen) apply false
+	alias(libs.plugins.jpa.schema.gen) apply false
 	alias(libs.plugins.openapi.generator) apply false
 	alias(libs.plugins.sonarqube)
 	alias(libs.plugins.spring.boot) apply false
@@ -84,7 +86,7 @@ subprojects {
 			into 'build/resources/main'
 		}
 
-		tasks.named("assemble").configure{
+		tasks.named("assemble").configure {
 			finalizedBy getLogConfig
 		}
 
@@ -105,10 +107,12 @@ subprojects {
 			}
 		}
 		tasks.withType(BootBuildImage).configureEach {
+			imageName = buildImageFullName
+			tags = [buildImageLatestTag]
 			environment = ['BP_JVM_TYPE'      : 'JRE',
 						   'BP_JVM_VERSION'   : containerJvmVersion,
 						   'JAVA_TOOL_OPTIONS': '-Djava.security.egd=file:/dev/./urandom',
-						   'BP_OCI_SOURCE': githubRepo]
+						   'BP_OCI_SOURCE'    : githubRepo]
 			publish = false
 			// We need curl for healthchecks and base builder does not include it
 			builder = "paketobuildpacks/builder:full"
@@ -122,13 +126,54 @@ subprojects {
 	}
 	// All modules use bmuschko plugin for pushing the image
 	pluginManager.withPlugin('com.bmuschko.docker-remote-api') {
-		task pushBuildImage(type: DockerPushImage, group: 'docker') {
+		tasks.register("pushBuildImage", DockerPushImage) {
+			images.add(buildImageFullName)
+			group = 'docker'
+
 			registryCredentials {
 				url = registry_repo
 				username = registry_username
 				password = registry_password
 			}
 		}
+
+		tasks.register("pullBuildImage", DockerPullImage) {
+			group = 'docker'
+			image = buildImageFullName
+
+			registryCredentials {
+				url = registry_repo
+				username = registry_username
+				password = registry_password
+			}
+		}
+		tasks.register("retagForRelease", DockerTagImage) {
+			dependsOn tasks.named("pullBuildImage")
+			group = 'docker'
+
+			tag = BUILD_VERSION_PREFIX
+			repository = buildImageName
+			targetImageId buildImageFullName
+
+		}
+		tasks.register("pushReleaseImage", DockerPushImage) {
+			dependsOn tasks.named("retagForRelease")
+			images.add(releaseImageFullName)
+			group = 'docker'
+
+			registryCredentials {
+				url = registry_repo
+				username = registry_username
+				password = registry_password
+			}
+		}
+
+		tasks.register("printImageFullName") {
+			doLast {
+				println buildImageFullName
+			}
+		}
+
 	}
 	pluginManager.withPlugin('node-base') {
 		tasks.withType(KarmaTestTask).configureEach {
@@ -159,7 +204,7 @@ sonarqube {
 
 
 task buildAllImages(group: 'dockerAll', description: 'Build docker images for all the existing modules.') {
-	dependsOn subprojects.collect { it.tasks.withType(BootBuildImage) } , subprojects.collect { it.tasks.withType(DockerBuildImage) }
+	dependsOn subprojects.collect { it.tasks.withType(BootBuildImage) }, subprojects.collect { it.tasks.withType(DockerBuildImage) }
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -202,15 +202,12 @@ sonarqube {
 	}
 }
 
-
-task buildAllImages(group: 'dockerAll', description: 'Build docker images for all the existing modules.') {
+tasks.register("buildAllImages") {
+	group = 'dockerAll'
+	description = 'Build docker images for all the existing modules.'
 	dependsOn subprojects.collect { it.tasks.withType(BootBuildImage) }, subprojects.collect { it.tasks.withType(DockerBuildImage) }
 }
 
-
-task pushAllImages(group: 'dockerAll', description: 'Push all existing images to repository. Will build missing images') {
-	dependsOn subprojects.collect { it.tasks.withType(DockerPushImage) }
-}
 
 check {
 	finalizedBy subprojects.collect { it.tasks.withType(JacocoReport) }

--- a/build.gradle
+++ b/build.gradle
@@ -208,7 +208,6 @@ tasks.register("buildAllImages") {
 	dependsOn subprojects.collect { it.tasks.withType(BootBuildImage) }, subprojects.collect { it.tasks.withType(DockerBuildImage) }
 }
 
-
 check {
 	finalizedBy subprojects.collect { it.tasks.withType(JacocoReport) }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,8 @@ subprojects {
 		}
 		tasks.withType(BootBuildImage).configureEach {
 			imageName = buildImageFullName
-			tags = [buildImageLatestTag]
+			// For local development we also create the latest tag.
+			tags = [buildImageName + ":latest"]
 			environment = ['BP_JVM_TYPE'      : 'JRE',
 						   'BP_JVM_VERSION'   : containerJvmVersion,
 						   'JAVA_TOOL_OPTIONS': '-Djava.security.egd=file:/dev/./urandom',
@@ -158,7 +159,8 @@ subprojects {
 		}
 		tasks.register("pushReleaseImage", DockerPushImage) {
 			dependsOn tasks.named("retagForRelease")
-			images.add(releaseImageFullName)
+			// Use the shorthand version tag for public releases
+			images.add(buildImageName + ":${BUILD_VERSION_PREFIX}")
 			group = 'docker'
 
 			registryCredentials {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-bmuschko-docker = "7.1.0"
+bmuschko-docker = "9.1.0"
 grgit = "5.0.0"
 flyway = "9.4.0"
 jpa-schema-gen = "1.1.20200614081240"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-bmuschko-docker = "9.1.0"
+bmuschko-docker = "7.1.0"
 grgit = "5.0.0"
 flyway = "9.4.0"
 jpa-schema-gen = "1.1.20200614081240"

--- a/svc-aca-py/build.gradle
+++ b/svc-aca-py/build.gradle
@@ -7,8 +7,6 @@ plugins {
 ext {
 	buildImageName = svcAcaPyImageName
 	buildImageFullName = svcAcaPyImageFullName
-	buildImageLatestTag = "${svcAcaPyImageName}:latest"
-	releaseImageFullName = "${svcAcaPyImageName}:${BUILD_VERSION_PREFIX}"
 }
 
 task buildImage(type: DockerBuildImage, group: 'docker') {

--- a/svc-aca-py/build.gradle
+++ b/svc-aca-py/build.gradle
@@ -4,20 +4,16 @@ plugins {
 	alias(libs.plugins.bmuschko.docker)
 }
 
+ext {
+	buildImageName = svcAcaPyImageName
+	buildImageFullName = svcAcaPyImageFullName
+	buildImageLatestTag = "${svcAcaPyImageName}:latest"
+	releaseImageFullName = "${svcAcaPyImageName}:${BUILD_VERSION_PREFIX}"
+}
+
 task buildImage(type: DockerBuildImage, group: 'docker') {
 	inputDir = file("${project.projectDir}")
 	images.add(svcAcaPyImageFullName)
 	images.add("${svcAcaPyImageName}:latest")
 	labels.put("org.opencontainers.image.source", "${githubRepo}")
-}
-
-pushBuildImage {
-	images.add(svcAcaPyImageFullName)
-}
-
-task printImageFullName {
-	doLast {
-		println "${svcAcaPyImageFullName}"
-		new File(buildDir, "acaPyImageTag").text = "${svcAcaPyImageFullName}"
-	}
 }

--- a/svc-aries-facade/build.gradle
+++ b/svc-aries-facade/build.gradle
@@ -38,18 +38,10 @@ configurations {
 	}
 }
 
-bootBuildImage {
-	imageName = svcAriesFacadeImageFullName
-	tags = ["${svcAriesFacadeImageName}:latest"]
+ext {
+	buildImageName = svcAriesFacadeImageName
+	buildImageFullName = svcAriesFacadeImageFullName
+	buildImageLatestTag = "${svcAriesFacadeImageName}:latest"
+	releaseImageFullName = "${svcAriesFacadeImageName}:${BUILD_VERSION_PREFIX}"
 }
 
-pushBuildImage {
-	images.add(svcAriesFacadeImageFullName)
-}
-
-task printImageFullName {
-	doLast {
-		println "${svcAriesFacadeImageFullName}"
-		new File(buildDir, "AriesFacadeImageTag").text = "${svcAriesFacadeImageFullName}"
-	}
-}

--- a/svc-aries-facade/build.gradle
+++ b/svc-aries-facade/build.gradle
@@ -41,7 +41,5 @@ configurations {
 ext {
 	buildImageName = svcAriesFacadeImageName
 	buildImageFullName = svcAriesFacadeImageFullName
-	buildImageLatestTag = "${svcAriesFacadeImageName}:latest"
-	releaseImageFullName = "${svcAriesFacadeImageName}:${BUILD_VERSION_PREFIX}"
 }
 

--- a/svc-tails-server/build.gradle
+++ b/svc-tails-server/build.gradle
@@ -7,8 +7,6 @@ plugins {
 ext {
 	buildImageName = svcTailsServerImageName
 	buildImageFullName = svcTailsServerImageFullName
-	buildImageLatestTag = "${svcTailsServerImageName}:latest"
-	releaseImageFullName = "${svcTailsServerImageName}:${BUILD_VERSION_PREFIX}"
 }
 
 task buildImage(type: DockerBuildImage, group: 'docker') {

--- a/svc-tails-server/build.gradle
+++ b/svc-tails-server/build.gradle
@@ -4,6 +4,13 @@ plugins {
 	alias(libs.plugins.bmuschko.docker)
 }
 
+ext {
+	buildImageName = svcTailsServerImageName
+	buildImageFullName = svcTailsServerImageFullName
+	buildImageLatestTag = "${svcTailsServerImageName}:latest"
+	releaseImageFullName = "${svcTailsServerImageName}:${BUILD_VERSION_PREFIX}"
+}
+
 task buildImage(type: DockerBuildImage, group: 'docker') {
 	inputDir = file("${project.projectDir}")
 	images.add(svcTailsServerImageFullName)
@@ -11,6 +18,3 @@ task buildImage(type: DockerBuildImage, group: 'docker') {
 	labels.put("org.opencontainers.image.source", "${githubRepo}")
 }
 
-pushBuildImage {
-	images.add(svcTailsServerImageFullName)
-}

--- a/svc-webhook/build.gradle
+++ b/svc-webhook/build.gradle
@@ -29,24 +29,14 @@ configurations {
 	}
 }
 
+ext {
+	buildImageName = svcWebhookImageName
+	buildImageFullName = svcWebhookImageFullName
+	buildImageLatestTag = "${svcWebhookImageName}:latest"
+	releaseImageFullName = "${svcWebhookImageName}:${BUILD_VERSION_PREFIX}"
+}
+
+
 test {
 	useJUnitPlatform()
-}
-
-// docker
-
-bootBuildImage {
-	imageName = svcWebhookImageFullName
-	tags = ["${svcWebhookImageName}:latest"]
-}
-
-pushBuildImage {
-	images.add(svcWebhookImageFullName)
-}
-
-task printImageFullName {
-	doLast {
-		println "${svcWebhookImageFullName}"
-		new File(buildDir, "beImageTag").text = "${svcWebhookImageFullName}"
-	}
 }

--- a/svc-webhook/build.gradle
+++ b/svc-webhook/build.gradle
@@ -32,8 +32,6 @@ configurations {
 ext {
 	buildImageName = svcWebhookImageName
 	buildImageFullName = svcWebhookImageFullName
-	buildImageLatestTag = "${svcWebhookImageName}:latest"
-	releaseImageFullName = "${svcWebhookImageName}:${BUILD_VERSION_PREFIX}"
 }
 
 

--- a/ui-issuer/build.gradle
+++ b/ui-issuer/build.gradle
@@ -13,8 +13,6 @@ dependencies {
 ext {
 	buildImageName = uiIssuerImageName
 	buildImageFullName = uiIssuerImageFullName
-	buildImageLatestTag = "${uiIssuerImageName}:latest"
-	releaseImageFullName = "${uiIssuerImageName}:${BUILD_VERSION_PREFIX}"
 }
 
 node {

--- a/ui-issuer/build.gradle
+++ b/ui-issuer/build.gradle
@@ -10,6 +10,13 @@ dependencies {
 	implementation project(":commons")
 }
 
+ext {
+	buildImageName = uiIssuerImageName
+	buildImageFullName = uiIssuerImageFullName
+	buildImageLatestTag = "${uiIssuerImageName}:latest"
+	releaseImageFullName = "${uiIssuerImageName}:${BUILD_VERSION_PREFIX}"
+}
+
 node {
 	download = false
 	version = "16.15.0"
@@ -54,13 +61,6 @@ tasks.named('check').configure {
 	dependsOn npmLint
 }
 
-task printImageFullName {
-	doLast {
-		println "${uiIssuerImageFullName}"
-		new File(buildDir, "uiIssuerImageFullName").text = "${uiIssuerImageFullName}"
-	}
-}
-
 task buildImage(type: DockerBuildImage, group: 'docker') {
 	inputDir = file("${project.projectDir}")
 	images.add("${uiIssuerImageFullName}")
@@ -70,6 +70,3 @@ task buildImage(type: DockerBuildImage, group: 'docker') {
 
 buildImage.dependsOn copyCommons
 
-pushBuildImage {
-	images.add(uiIssuerImageFullName)
-}

--- a/ui-verifier/build.gradle
+++ b/ui-verifier/build.gradle
@@ -13,8 +13,6 @@ dependencies {
 ext {
 	buildImageName = uiVerifierImageName
 	buildImageFullName = uiVerifierImageFullName
-	buildImageLatestTag = "${uiVerifierImageName}:latest"
-	releaseImageFullName = "${uiVerifierImageName}:${BUILD_VERSION_PREFIX}"
 }
 
 node {

--- a/ui-verifier/build.gradle
+++ b/ui-verifier/build.gradle
@@ -10,6 +10,13 @@ dependencies {
 	implementation project(":commons")
 }
 
+ext {
+	buildImageName = uiVerifierImageName
+	buildImageFullName = uiVerifierImageFullName
+	buildImageLatestTag = "${uiVerifierImageName}:latest"
+	releaseImageFullName = "${uiVerifierImageName}:${BUILD_VERSION_PREFIX}"
+}
+
 node {
 	download = false
 	version = "16.15.0"
@@ -54,13 +61,6 @@ tasks.named('check').configure {
 	dependsOn npmLint
 }
 
-task printImageFullName {
-	doLast {
-		println "${uiVerifierImageFullName}"
-		new File(buildDir, "uiVerifierImageFullName").text = "${uiVerifierImageFullName}"
-	}
-}
-
 task buildImage(type: DockerBuildImage, group: 'docker') {
 	inputDir = file("${project.projectDir}")
 	images.add("${uiVerifierImageFullName}")
@@ -70,6 +70,4 @@ task buildImage(type: DockerBuildImage, group: 'docker') {
 
 buildImage.dependsOn copyCommons
 
-pushBuildImage {
-	images.add(uiVerifierImageFullName)
-}
+


### PR DESCRIPTION
- Generalized the docker specific tasks, push/pull/tag , in the main build.gradle. The subproject configurations became shorter this way. There is no need to configure each task in each subproject with the correct image name. Instead the global setting uses lazy evaluated tasks with property references, and we add these properties to the subprojects in the `ext{}` block.
- `pushAllImages `is not necesssary as a separate task. Gradle will call the existing tasks in subprojects simply by calling `./gradlew pushBuildImage`
- to tag these existing images for released, (by pulling the image, add the new tag, and pushing it). simple call **`./gradlew pushReleaseImage`**. This is the new task that will be needed in the new job.
- as an additional cleanup the container scan workflow was updated. Thanks to the cleaned up task structure and our experience with the matrix, this becomes a lot shorter.