### PR TITLE
Support data uri input for claim value

### DIFF
--- a/api-issuer/src/main/resources/application.yml
+++ b/api-issuer/src/main/resources/application.yml
@@ -5,7 +5,8 @@ logging:
   level:
     root: ${LOG_LEVEL:INFO}
 
-aries.facade.basePath: ${ARIES_FACADE_BASEPATH:http://localhost:8000}
+aries.facade:
+  basePath: ${ARIES_FACADE_BASEPATH:http://localhost:8000}
 
 spring:
   jpa:

--- a/svc-aries-facade/src/main/java/com/adnovum/vcms/aries/facade/service/AcaPyClient.java
+++ b/svc-aries-facade/src/main/java/com/adnovum/vcms/aries/facade/service/AcaPyClient.java
@@ -59,6 +59,8 @@ public class AcaPyClient {
 
 	private final MappingJackson2HttpMessageConverter springMvcJacksonConverter;
 
+	private final AcaPyProperties acapyProperties;
+
 	@Autowired
 	public AcaPyClient(AcaPyProperties acapyProperties) {
 		springMvcJacksonConverter = createMappingJacksonHttpMessageConverter();
@@ -75,6 +77,7 @@ public class AcaPyClient {
 		issueCredentialV10Api = new IssueCredentialV10Api(apiClient);
 		revocationApi = new RevocationApi(apiClient);
 		schemaApi = new SchemaApi(apiClient);
+		this.acapyProperties = acapyProperties;
 	}
 
 	protected ObjectMapper createObjectMapper() {
@@ -151,11 +154,11 @@ public class AcaPyClient {
 		credentialPreview.atType("https://didcomm.org/issue-credential/2.0/credential-preview");
 
 		V10CredentialFreeOfferRequest offer = new V10CredentialFreeOfferRequest();
-		offer.setAutoIssue(Boolean.FALSE);
-		offer.setAutoRemove(Boolean.TRUE);
+		offer.setAutoIssue(acapyProperties.getCredentialOfferAutoIssue());
+		offer.setAutoRemove(acapyProperties.getCredentialOfferAutoRemove());
 		offer.setCredDefId(creDefId);
 		offer.setConnectionId(connectionId);
-		offer.setTrace(Boolean.TRUE);
+		offer.setTrace(acapyProperties.getCredentialOfferTrace());
 		offer.setComment(comment);
 		offer.setCredentialPreview(credentialPreview);
 

--- a/svc-aries-facade/src/main/java/com/adnovum/vcms/aries/facade/service/AcaPyProperties.java
+++ b/svc-aries-facade/src/main/java/com/adnovum/vcms/aries/facade/service/AcaPyProperties.java
@@ -18,4 +18,10 @@ public class AcaPyProperties {
 	private String proofName = "present proof request";
 
 	private String nonce = "123456789";
+
+	private Boolean credentialOfferAutoRemove;
+
+	private Boolean credentialOfferAutoIssue;
+
+	private Boolean credentialOfferTrace;
 }

--- a/svc-aries-facade/src/main/resources/application.yml
+++ b/svc-aries-facade/src/main/resources/application.yml
@@ -10,5 +10,8 @@ acapy:
   comment: "present proof request"
   proofName: "present proof request"
   nonce: "123456789"
+  credentialOfferAutoRemove: false
+  credentialOfferAutoIssue: false
+  credentialOfferTrace: true
 
 management.server.port: 9000

--- a/svc-aries-facade/src/test/java/com/adnovum/vcms/aries/facade/service/AcaPyClientTest.java
+++ b/svc-aries-facade/src/test/java/com/adnovum/vcms/aries/facade/service/AcaPyClientTest.java
@@ -52,6 +52,9 @@ class AcaPyClientTest extends AriesFacadeIntBase {
 		String baseUrl = String.format(acaPyProperties.getBasePath() + ":%s", mockBackEnd.getPort());
 		AcaPyProperties acapyProperties = new AcaPyProperties();
 		acapyProperties.setBasePath(baseUrl);
+		acapyProperties.setCredentialOfferAutoIssue(acaPyProperties.getCredentialOfferAutoIssue());
+		acapyProperties.setCredentialOfferTrace(acaPyProperties.getCredentialOfferTrace());
+		acapyProperties.setCredentialOfferAutoRemove(acaPyProperties.getCredentialOfferAutoIssue());
 		acapyClient = new AcaPyClient(acapyProperties);
 	}
 
@@ -148,7 +151,7 @@ class AcaPyClientTest extends AriesFacadeIntBase {
 						"\",\"proof_request",
 						"\":{\"name\":\"present proof request\",\"non_revoked\":{\"from\":",
 						"\"to\":",
-						"},\"nonce\":\"123456789\",",
+						"},\"nonce\":\"78789\",",
 						"\"requested_attributes\":{\"generateProofRequest_attribute2\":{\"name"
 						, "\":\"generateProofRequest_attribute2\","
 						, "\"non_revoked\":{\"from\":",
@@ -198,7 +201,7 @@ class AcaPyClientTest extends AriesFacadeIntBase {
 		RecordedRequest request = mockBackEnd.takeRequest();
 
 		assertThat(request.getBody().readUtf8()).isEqualTo(
-				"{\"auto_issue\":false,\"auto_remove\":true,\"comment\":\"sendCredentialOffer_comment\","
+				"{\"auto_issue\":false,\"auto_remove\":false,\"comment\":\"sendCredentialOffer_comment\","
 						+ "\"connection_id\":\"" + connectionId + "\","
 						+ "\"cred_def_id\":\"sendCredentialOffer_credfDefId\","
 						+ "\"credential_preview\":{\"@type\":\"https://didcomm"
@@ -237,7 +240,7 @@ class AcaPyClientTest extends AriesFacadeIntBase {
 		RecordedRequest request = mockBackEnd.takeRequest();
 
 		assertThat(request.getBody().readUtf8()).isEqualTo(
-				"{\"auto_issue\":false,\"auto_remove\":true,\"comment\":\"datauri_comment\","
+				"{\"auto_issue\":false,\"auto_remove\":false,\"comment\":\"datauri_comment\","
 						+ "\"connection_id\":\"" + connectionId + "\","
 						+ "\"cred_def_id\":\"datauri_credfDefId\","
 						+ "\"credential_preview\":{\"@type\":\"https://didcomm"

--- a/svc-aries-facade/src/test/java/com/adnovum/vcms/aries/facade/service/AcaPyClientTest.java
+++ b/svc-aries-facade/src/test/java/com/adnovum/vcms/aries/facade/service/AcaPyClientTest.java
@@ -198,7 +198,7 @@ class AcaPyClientTest extends AriesFacadeIntBase {
 		RecordedRequest request = mockBackEnd.takeRequest();
 
 		assertThat(request.getBody().readUtf8()).isEqualTo(
-				"{\"auto_issue\":false,\"auto_remove\":false,\"comment\":\"sendCredentialOffer_comment\","
+				"{\"auto_issue\":false,\"auto_remove\":true,\"comment\":\"sendCredentialOffer_comment\","
 						+ "\"connection_id\":\"" + connectionId + "\","
 						+ "\"cred_def_id\":\"sendCredentialOffer_credfDefId\","
 						+ "\"credential_preview\":{\"@type\":\"https://didcomm"
@@ -215,10 +215,10 @@ class AcaPyClientTest extends AriesFacadeIntBase {
 	@ParameterizedTest
 	@CsvSource(value = {
 			"simple text Claim.text/plain.simple text Claim",
-			"data:,implicitTextClaim.text/plain.implicitTextClaim",
-			"data:text/plain;base64,EncodedDataWillBePersisted.text/plain.EncodedDataWillBePersisted",
-			"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/4QBMRXhpZg.image/jpeg./9j/4AAQSkZJRgABAQEAYABgAAD/4QBMRXhpZg",
-	        "data:image/png;base64,aW1hZ2VEYXRhSlBHAAAA.image/png.aW1hZ2VEYXRhSlBHAAAA"}, delimiter = '.')
+			"data:,implicitTextClaim.text/plain.data:,implicitTextClaim",
+			"data:text/plain;base64,fullDataUriIssued.text/plain.data:text/plain;base64,fullDataUriIssued",
+			"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/4QBMRXhpZg.image/jpeg.data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/4QBMRXhpZg",
+	        "data:image/png;base64,aW1hZ2VEYXRhSlBHAAAA.image/png.data:image/png;base64,aW1hZ2VEYXRhSlBHAAAA"}, delimiter = '.')
 	void sendCredentialOfferWhereSomeClaimsAreDataURIs(String dataFromFrontend, String expectedMimeType, String expectedClaimValue) throws JsonProcessingException, InterruptedException {
 		String test = "datauri";
 		UUID connectionId = UUID.randomUUID();
@@ -237,7 +237,7 @@ class AcaPyClientTest extends AriesFacadeIntBase {
 		RecordedRequest request = mockBackEnd.takeRequest();
 
 		assertThat(request.getBody().readUtf8()).isEqualTo(
-				"{\"auto_issue\":false,\"auto_remove\":false,\"comment\":\"datauri_comment\","
+				"{\"auto_issue\":false,\"auto_remove\":true,\"comment\":\"datauri_comment\","
 						+ "\"connection_id\":\"" + connectionId + "\","
 						+ "\"cred_def_id\":\"datauri_credfDefId\","
 						+ "\"credential_preview\":{\"@type\":\"https://didcomm"

--- a/svc-aries-facade/src/test/java/com/adnovum/vcms/aries/facade/service/AcaPyClientTest.java
+++ b/svc-aries-facade/src/test/java/com/adnovum/vcms/aries/facade/service/AcaPyClientTest.java
@@ -18,6 +18,8 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
@@ -177,7 +179,7 @@ class AcaPyClientTest extends AriesFacadeIntBase {
 	}
 
 	@Test
-	void sendCredentialOffer() throws JsonProcessingException, InterruptedException {
+	void sendCredentialOfferCreatesValidRequestWithMultipleTextClaims() throws JsonProcessingException, InterruptedException {
 		String test = "sendCredentialOffer";
 		UUID connectionId = UUID.randomUUID();
 		V10CredentialExchange mockresponse = new V10CredentialExchange();
@@ -206,6 +208,41 @@ class AcaPyClientTest extends AriesFacadeIntBase {
 						+ "\"name\":\"sendCredentialOffer_claim2\",\"value\":\"sendCredentialOffer_value2\"},"
 						+ "{\"mime-type\":\"text/plain\","
 						+ "\"name\":\"sendCredentialOffer_claim1\",\"value\":\"sendCredentialOffer_value1\"}]},"
+						+ "\"trace\":true}");
+		assertThat(request.getRequestLine()).isEqualTo("POST /issue-credential/send-offer HTTP/1.1");
+	}
+
+	@ParameterizedTest
+	@CsvSource(value = {
+			"simple text Claim.text/plain.simple text Claim",
+			"data:,implicitTextClaim.text/plain.implicitTextClaim",
+			"data:text/plain;base64,EncodedDataWillBePersisted.text/plain.EncodedDataWillBePersisted",
+			"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/4QBMRXhpZg.image/jpeg./9j/4AAQSkZJRgABAQEAYABgAAD/4QBMRXhpZg",
+	        "data:image/png;base64,aW1hZ2VEYXRhSlBHAAAA.image/png.aW1hZ2VEYXRhSlBHAAAA"}, delimiter = '.')
+	void sendCredentialOfferWhereSomeClaimsAreDataURIs(String dataFromFrontend, String expectedMimeType, String expectedClaimValue) throws JsonProcessingException, InterruptedException {
+		String test = "datauri";
+		UUID connectionId = UUID.randomUUID();
+		V10CredentialExchange mockresponse = new V10CredentialExchange();
+		mockBackEnd.enqueue(new MockResponse()
+				.setBody(objectMapper.writeValueAsString(mockresponse))
+				.addHeader("Content-Type", "application/json"));
+
+		Map<String, String> claimMap = new HashMap<>();
+		claimMap.put("testClaimKey", dataFromFrontend);
+
+
+		assertThat(acapyClient.sendCredentialOffer(test + "_credfDefId", connectionId, test + "_comment",
+				claimMap)).isEqualTo(mockresponse);
+
+		RecordedRequest request = mockBackEnd.takeRequest();
+
+		assertThat(request.getBody().readUtf8()).isEqualTo(
+				"{\"auto_issue\":false,\"auto_remove\":false,\"comment\":\"datauri_comment\","
+						+ "\"connection_id\":\"" + connectionId + "\","
+						+ "\"cred_def_id\":\"datauri_credfDefId\","
+						+ "\"credential_preview\":{\"@type\":\"https://didcomm"
+						+ ".org/issue-credential/2.0/credential-preview\",\"attributes\":[{\"mime-type\":\""+expectedMimeType+"\","
+						+ "\"name\":\"testClaimKey\",\"value\":\""+expectedClaimValue+"\"}]},"
 						+ "\"trace\":true}");
 		assertThat(request.getRequestLine()).isEqualTo("POST /issue-credential/send-offer HTTP/1.1");
 	}

--- a/svc-aries-facade/src/test/java/com/adnovum/vcms/aries/facade/service/AcaPyPropertiesTest.java
+++ b/svc-aries-facade/src/test/java/com/adnovum/vcms/aries/facade/service/AcaPyPropertiesTest.java
@@ -1,0 +1,20 @@
+package com.adnovum.vcms.aries.facade.service;
+
+import com.adnovum.vcms.aries.facade.AriesFacadeIntBase;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class AcaPyPropertiesTest extends AriesFacadeIntBase {
+
+	@Test
+	void getBaseAcaPyPropertiesAreSet() {
+		assertThat(acaPyProperties.getBasePath()).isNotNull();
+		assertThat(acaPyProperties.getNonce()).isEqualTo("78789");
+		assertThat(acaPyProperties.getComment()).isNotNull();
+		assertThat(acaPyProperties.getProofName()).isNotNull();
+		assertThat(acaPyProperties.getCredentialOfferTrace()).isTrue();
+		assertThat(acaPyProperties.getCredentialOfferAutoRemove()).isFalse();
+		assertThat(acaPyProperties.getCredentialOfferAutoIssue()).isFalse();
+	}
+}

--- a/svc-aries-facade/src/test/resources/application-test.yml
+++ b/svc-aries-facade/src/test/resources/application-test.yml
@@ -6,4 +6,9 @@ logging.level:
   org.apache.http.impl.conn.DefaultHttpClientConnectionOperator: DEBUG
   org.apache.http.headers: DEBUG
 
-acapy.basePath: http://localhost
+acapy:
+  basePath: http://localhost
+  nonce: 78789
+  credentialOfferAutoRemove: false
+  credentialOfferAutoIssue: false
+  credentialOfferTrace: true


### PR DESCRIPTION
The frontend might return a data uri as claim value. The main use case is storing images, where we need to set the correct mime type. The data uri is used
as a source to identify the mime type.

When a data uri is found the value is persisted as-is, which normally means the base64 encoded value.
This needs to be compatible with the wallet apps.

To support backwards compatibility if data uri is not detected, we just store the claim value as clear text.