### PR TITLE
Acapy update to 0.8.1

### DIFF
--- a/svc-aca-py/Dockerfile
+++ b/svc-aca-py/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.6-indy-1.16.0-0.8.1
+FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-indy-1.16.0-0.8.1
 
 ADD util/start_wallet_from_seed.sh ./start_wallet_from_seed.sh
 RUN cat ./start_wallet_from_seed.sh


### PR DESCRIPTION
Move to python 3.9 hyperledger package repository images as suggested in [acapy release notes](https://github.com/hyperledger/aries-cloudagent-python/releases/tag/0.8.0)