### PR TITLE
Update acapy API to 0.8.1

### DIFF
--- a/commons/contract/svc-aca-py.json
+++ b/commons/contract/svc-aca-py.json
@@ -1,7 +1,7 @@
 {
 "swagger" : "2.0",
 "info" : {
-	"version" : "v0.8.0",
+	"version" : "v0.8.1",
 	"title" : "VMCS Aries Cloud Agent"
 },
 "tags" : [ {


### PR DESCRIPTION
This is a leftover update.
Acapy runtime is already 0.8.1.
No other changes in the API.