### PR TITLE
Update gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.caching=true
 
-BUILD_VERSION_PREFIX=1.2.0
+BUILD_VERSION_PREFIX=1.2.1


### PR DESCRIPTION
Time to bump the version number and release Version 1.2.1. 

Acapy upgrade and related updates are minor changes, so we do a minor change as well. We would like to use these fixed on other solutions, and anyway makes sense to regularly release the state.